### PR TITLE
fix : no main function execution on import

### DIFF
--- a/python/exir-api.py
+++ b/python/exir-api.py
@@ -81,4 +81,5 @@ def main():
     order = create_order(symbol, side, size, price, type)
     print('Order response:', order)
 
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
now you can import the example without accidentally executing the main function. the main func will only get executed when the user runs exir-api.py.